### PR TITLE
Set map afterRender

### DIFF
--- a/addon/components/mapbox-map.js
+++ b/addon/components/mapbox-map.js
@@ -8,12 +8,13 @@ export default Ember.Component.extend({
   mapId: null,
 
   setup: Ember.on('didInsertElement', function() {
-    let map = L.mapbox.map(this.get('divId'), this.get('mapId'));
+    Ember.run.scheduleOnce('afterRender', this, function () {
+      let map = L.mapbox.map(this.get('divId'), this.get('mapId'));
 
-    if (this.get('center') && this.get('zoom')) {
-      map.setView(this.get('center'), this.get('zoom'));
-    }
-
-    this.set('map', map);
+      if (this.get('center') && this.get('zoom')) {
+        map.setView(this.get('center'), this.get('zoom'));
+      }
+      this.set('map', map);
+    });
   }),
 });


### PR DESCRIPTION
To prevent warnings in console to not update properties in didInsertElement, moved the code to afterRender.