### PR TITLE
Fixed a warning by surrounding marker creation with runloop magic.

### DIFF
--- a/addon/components/mapbox-marker.js
+++ b/addon/components/mapbox-marker.js
@@ -19,20 +19,22 @@ export default Ember.Component.extend({
   }),
 
   setup: Ember.on('didInsertElement', function() {
-    let marker = L.marker(this.get('coordinates'), {
-      icon: L.mapbox.marker.icon({
-        'marker-color': this.get('color'),
-        'marker-size': this.get('size'),
-        'marker-symbol': this.get('symbol'),
-      }),
-    });
-    marker.bindPopup(this.get('popup-title'));
+    Ember.run.scheduleOnce('afterRender', this, function () {
+      let marker = L.marker(this.get('coordinates'), {
+        icon: L.mapbox.marker.icon({
+          'marker-color': this.get('color'),
+          'marker-size': this.get('size'),
+          'marker-symbol': this.get('symbol'),
+        }),
+      });
+      marker.bindPopup(this.get('popup-title'));
 
-    marker.on('click', () => {
-      this.sendAction('onclick');
-    });
+      marker.on('click', () => {
+        this.sendAction('onclick');
+      });
 
-    this.set('marker', marker);
+      this.set('marker', marker);
+    });
   }),
 
   teardown: Ember.on('willDestroyElement', function() {


### PR DESCRIPTION
Surrounded marker creation and setting with runloop magic to prevent a warning like this:
DEPRECATION: A property of <Ember.SomeView:emberXXX> was modified inside the didInsertElement hook. You should never change properties on components, services or models during didInsertElement because it causes significant performance degradation.