### PR TITLE
Use willRender instead of didInsertElement/afterRender

### DIFF
--- a/addon/components/mapbox-marker.js
+++ b/addon/components/mapbox-marker.js
@@ -18,23 +18,21 @@ export default Ember.Component.extend({
     }
   }),
 
-  setup: Ember.on('didInsertElement', function() {
-    Ember.run.scheduleOnce('afterRender', this, function () {
-      let marker = L.marker(this.get('coordinates'), {
-        icon: L.mapbox.marker.icon({
-          'marker-color': this.get('color'),
-          'marker-size': this.get('size'),
-          'marker-symbol': this.get('symbol'),
-        }),
-      });
-      marker.bindPopup(this.get('popup-title'));
-
-      marker.on('click', () => {
-        this.sendAction('onclick');
-      });
-
-      this.set('marker', marker);
+  setup: Ember.on('willRender', function() {
+    let marker = L.marker(this.get('coordinates'), {
+      icon: L.mapbox.marker.icon({
+        'marker-color': this.get('color'),
+        'marker-size': this.get('size'),
+        'marker-symbol': this.get('symbol'),
+      }),
     });
+    marker.bindPopup(this.get('popup-title'));
+
+    marker.on('click', () => {
+      this.sendAction('onclick');
+    });
+
+    this.set('marker', marker);
   }),
 
   teardown: Ember.on('willDestroyElement', function() {


### PR DESCRIPTION
refs #16 

I think this is a more sensible solution to the deprecation warning. Tested this locally in live-ops and it seemed to work. No real reason to wait for didInsertElement to create the marker since it doesn't depend on anything else. 