### PR TITLE
setup hook for mapbox-marker cached for init instead of willRender

### DIFF
--- a/addon/components/mapbox-marker.js
+++ b/addon/components/mapbox-marker.js
@@ -19,7 +19,7 @@ export default Ember.Component.extend({
     }
   }),
 
-  setup: Ember.on('willRender', function() {
+  setup: Ember.on('init', function() {
     let marker = L.marker(this.get('coordinates'), {
       icon: L.mapbox.marker.icon({
         'marker-color': this.get('color'),


### PR DESCRIPTION
Clicking on a marker to show the pop up window is breaking the `willRender` cache thus forcing the setup hook to fire for every marker on the page causing them to redundantly add copies of themselves to the map. This changes it so the setup hook is only fired when the marker is first initialized.